### PR TITLE
Log graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
-To get extension bundled:
-1) npm install in /client folder
-2) npm run build in /client folder
+# Obsidian Developer Tool 8.0
+
+The Obsidian Developer Tool 8.0 is the revamped DevTool for applications using Obsidian with no additonal configuration needed. It's an easy-to-use chrome developer tool extension where users can:
+
+- visualize cache performance metrics (i.e. hit ratio, time graphs)
+- view previous queries through a query log and hit, miss, and mutation time trends
+
+The Obsidian Developer Tool is an open-source developer tool accelerated by OS Labs and developed by [David Kim](https://github.com/davidtoyoukim), [David Norman](https://github.com/DavidMNorman), [Eileen Cho](https://github.com/exlxxn), and [Joan Manto](https://github.com/JoanManto).
+
+# Installation
+
+Currently, the easiest way to use the developer tool is to build from source and manually add as a chrome extension. To build the latest version, please follow the below instructions.
+
+```
+git clone -link-
+cd client
+npm install
+npm run build
+```
+
+In the Chrome Extensions Page (chrome://extensions/), toggle "Developer Mode" on in the upper righthand corner. Click on the "Load Unpacked" button, and navigate to the client folder of the Obsidian repo. Click "Select", and the developer tool should now be loaded and available in the developer tools panel.
+
+# Features
+
+**Dashboard** <br/>
+The default landing page of the Obsidian Developer Tool is the dashboard, where the query hit rate, query total, and query time graph are displayed. These metrics are updated live as the user executes queries and mutations to test their application. Additional details like algorithm used and total capacity can also be viewed in this page.
+
+-- add photo here --
+
+**Query Log** <br/>
+The query log is broken up into two parts, the query list and the query graph. Each query in the list can be selected to display details about that query. The query log graph displays each query you've made, organized by whether it was a cache hit, cache miss, or mutation. Clicking on any query node in the graph will isolate that selected query in the list, allowing you to easily check the details of that particular query.
+
+-- add photo here --
+
+**Usage Note** <br/>
+Use of this developer tool requires Obsidian version 8.0 or greater.
+
+# More Information
+Obsidian and Obsidian Demo documentation:
+* [Obsidian](https://github.com/open-source-labs/obsidian)
+* [Obsidian Demo]()

--- a/client/src/components/listItem.tsx
+++ b/client/src/components/listItem.tsx
@@ -16,13 +16,20 @@ const ListItem = (props: ListItemType) => {
     const filtered = state.queryMetrics.filter(filter);
     const index = filtered.indexOf(props.data);
     console.log('index is', index);
+    // const hits = [...state.hitSize].fill(8);
+    // const misses = [...state.missSize].fill(8);
+    // const mutations = [...state.mutationSize].fill(8);
     const sizeArr = new Array(filtered.length);
     sizeArr.fill(8);
-    sizeArr[index] = 20
+    sizeArr[index] = 20;
     if (props.data.mutation){
       dispatch({type: 'SET_MUTATIONSIZE', payload: sizeArr});
+      // dispatch({type: 'SET_HITSIZE', payload: hits});
+      // dispatch({type: 'SET_MISSSIZE', payload: misses})
     } else if (props.data.hit){
       dispatch({type: 'SET_HITSIZE', payload: sizeArr });
+      // dispatch({type: 'SET_MISSSIZE', payload: misses});
+      // dispatch({type: 'SET_MUTATIONSIZE', payload: mutations})
     } 
     else dispatch({type: 'SET_MISSSIZE', payload: sizeArr});
   };

--- a/client/src/components/listItem.tsx
+++ b/client/src/components/listItem.tsx
@@ -4,13 +4,27 @@ import { useQueryContext } from '../hooks/useQueryContext';
 
 // individual items in the list of query logs
 const ListItem = (props: ListItemType) => {
-  const { state } = useQueryContext();
+  const { state, dispatch } = useQueryContext();
 
   // to allow for each item to expand to show more details on click and collapse if already expanded
   const [expand, setExpand] = useState<boolean>(false);
 
   const handleClick = () => {
     setExpand(!expand);
+    const filter = props.data.mutation ? (el: any) => el.mutation : (props.data.hit ? (el: any) => el.hit && !el.mutation : (el: any) => !el.hit && !el.mutation);
+    console.log('filter is', filter);
+    const filtered = state.queryMetrics.filter(filter);
+    const index = filtered.indexOf(props.data);
+    console.log('index is', index);
+    const sizeArr = new Array(filtered.length);
+    sizeArr.fill(8);
+    sizeArr[index] = 20
+    if (props.data.mutation){
+      dispatch({type: 'SET_MUTATIONSIZE', payload: sizeArr});
+    } else if (props.data.hit){
+      dispatch({type: 'SET_HITSIZE', payload: sizeArr });
+    } 
+    else dispatch({type: 'SET_MISSSIZE', payload: sizeArr});
   };
 
 //   console.log('props.data in listItem is', props.data);

--- a/client/src/components/queryLogGraph.tsx
+++ b/client/src/components/queryLogGraph.tsx
@@ -99,7 +99,7 @@ const QueryLogGraph = (props: any) => {
         borderColor: 'rgba(25, 201, 16, 0.4)',
         pointBackgroundColor: 'rgb(25, 201, 16)',
         pointRadius: state.hitSize,
-        pointHoverRadius: 25
+        pointHoverRadius: 20
       },
       {
         label: 'Miss Time',

--- a/client/src/components/reverseList.tsx
+++ b/client/src/components/reverseList.tsx
@@ -11,7 +11,7 @@ const ReverseList = (props: any) => {
   // create list item for each query metric and push into array that will be shown in component
   const list: Array<JSX.Element> = [];
   for(let i: number = 0; i < state.queryMetrics.length; i++){
-    list.push(<ListItem data={state.queryMetrics[i]}/>)
+    list.push(<ListItem data={state.queryMetrics[i]} />)
   };
 
   return(

--- a/client/src/contexts/queryContext.tsx
+++ b/client/src/contexts/queryContext.tsx
@@ -55,6 +55,39 @@ const queryMetricReducer = (state: State, action: action): State => {
         missSize: [...state.missSize],
         mutationSize: [...state.mutationSize],
         open: action.payload
+      };
+
+    case 'SET_HITSIZE':
+      return {
+        totalQueries: state.totalQueries,
+        totalHits: state.totalHits,
+        queryMetrics: [...state.queryMetrics],
+        hitSize: action.payload,
+        missSize: [...state.missSize],
+        mutationSize: [...state.mutationSize],
+        open: state.open
+      };
+
+    case 'SET_MUTATIONSIZE':
+      return {
+        totalQueries: state.totalQueries,
+        totalHits: state.totalHits,
+        queryMetrics: [...state.queryMetrics],
+        hitSize: [...state.hitSize],
+        missSize: [...state.missSize],
+        mutationSize: action.payload,
+        open: state.open
+      };
+    
+    case 'SET_MISSSIZE':
+      return {
+        totalQueries: state.totalQueries,
+        totalHits: state.totalHits,
+        queryMetrics: [...state.queryMetrics],
+        hitSize: [...state.hitSize],
+        missSize: action.payload,
+        mutationSize: [...state.mutationSize],
+        open: state.open
       }
 
     default:

--- a/client/src/contexts/queryContext.tsx
+++ b/client/src/contexts/queryContext.tsx
@@ -51,42 +51,48 @@ const queryMetricReducer = (state: State, action: action): State => {
         totalQueries: state.totalQueries,
         totalHits: state.totalHits,
         queryMetrics: [...state.queryMetrics],
-        hitSize: [...state.hitSize],
-        missSize: [...state.missSize],
-        mutationSize: [...state.mutationSize],
+        hitSize: [...state.hitSize].fill(8),
+        missSize: [...state.missSize].fill(8),
+        mutationSize: [...state.mutationSize].fill(8),
         open: action.payload
       };
 
     case 'SET_HITSIZE':
+      const newMiss = [...state.missSize].fill(8);
+      const newMutation = [...state.mutationSize].fill(8);
       return {
         totalQueries: state.totalQueries,
         totalHits: state.totalHits,
         queryMetrics: [...state.queryMetrics],
         hitSize: action.payload,
-        missSize: [...state.missSize],
-        mutationSize: [...state.mutationSize],
+        missSize: newMiss,
+        mutationSize: newMutation,
         open: state.open
       };
 
     case 'SET_MUTATIONSIZE':
+      const newHit = [...state.hitSize].fill(8);
+      const newMisses = [...state.missSize].fill(8);
       return {
         totalQueries: state.totalQueries,
         totalHits: state.totalHits,
         queryMetrics: [...state.queryMetrics],
-        hitSize: [...state.hitSize],
-        missSize: [...state.missSize],
+        hitSize: newHit,
+        missSize: newMisses,
         mutationSize: action.payload,
         open: state.open
       };
     
     case 'SET_MISSSIZE':
+      const newHits = [...state.hitSize].fill(8);
+      const newMutations = [...state.mutationSize].fill(8);
       return {
         totalQueries: state.totalQueries,
         totalHits: state.totalHits,
         queryMetrics: [...state.queryMetrics],
-        hitSize: [...state.hitSize],
+        hitSize: newHits,
         missSize: action.payload,
-        mutationSize: [...state.mutationSize],
+        mutationSize: newMutations,
         open: state.open
       }
 

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -17,7 +17,11 @@ export type action = {
 
 export type ListItemType = {
   data: {
-    [key: string]: string | number | boolean;
+    date: string,
+    time: number, 
+    hit: boolean, 
+    query: string, 
+    mutation: boolean
   },
 };
 


### PR DESCRIPTION
Added the ability for the query log to be clicked on and only increase the size of the related node while resetting the size of all the other nodes. 

In addition, clicking on any node in the graph resets all node sizes. 

We accomplished this through useContext and dispatches.